### PR TITLE
Convert device group commits to template stack commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.6.0
+Features:
+- Improve management job performance by converting device group commits to template stack commits.
+
 2.5.0
 Features:
 - Add support for multiple Device Groups. You can now specify a comma-delimited list of Device Groups for your Certificate Store. i.e. `Group 1;Group 2;Group 3`.

--- a/PaloAlto.IntegrationTests/BaseIntegrationTest.cs
+++ b/PaloAlto.IntegrationTests/BaseIntegrationTest.cs
@@ -16,16 +16,32 @@ using Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs;
 using Keyfactor.Orchestrators.Common.Enums;
 using Keyfactor.Orchestrators.Extensions;
 using Keyfactor.Orchestrators.Extensions.Interfaces;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
 using PaloAlto.IntegrationTests.Models;
+using PaloAlto.Tests.Common.TestUtilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace PaloAlto.IntegrationTests;
 
 public abstract class BaseIntegrationTest
 {
     protected readonly string MockCertificatePassword = "sldfklsdfsldjfk";
+    protected readonly ILogger Logger;
+
+    public BaseIntegrationTest(ITestOutputHelper output)
+    {
+      var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder
+          .SetMinimumLevel(LogLevel.Trace)
+          .AddProvider(new XunitLoggerProvider(output));
+      });
+        
+      Logger = loggerFactory.CreateLogger<BaseIntegrationTest>();
+    }
     
     protected void AssertJobSuccess(JobResult result, string context)
     {
@@ -75,7 +91,7 @@ public abstract class BaseIntegrationTest
         mgmtSecretResolver
             .Setup(m => m.Resolve(It.Is<string>(s => s == config.ServerPassword)))
             .Returns(() => config.ServerPassword);
-        var mgmt = new Management(mgmtSecretResolver.Object);
+        var mgmt = new Management(mgmtSecretResolver.Object, Logger);
         return mgmt.ProcessJob(config);
     }
     

--- a/PaloAlto.IntegrationTests/InventoryIntegrationTests.cs
+++ b/PaloAlto.IntegrationTests/InventoryIntegrationTests.cs
@@ -14,11 +14,17 @@
 
 using PaloAlto.IntegrationTests.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace PaloAlto.IntegrationTests;
 
 public class InventoryIntegrationTests : BaseIntegrationTest
 {
+    public InventoryIntegrationTests(ITestOutputHelper output): base(output)
+    {
+        
+    }
+    
     #region Firewall Tests
 
     // Test Case 6 repeats across Management + Inventory. Keeping number in place for parity.

--- a/PaloAlto.IntegrationTests/ManagementIntegrationTests.cs
+++ b/PaloAlto.IntegrationTests/ManagementIntegrationTests.cs
@@ -15,11 +15,16 @@
 using PaloAlto.IntegrationTests.Generators;
 using PaloAlto.IntegrationTests.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace PaloAlto.IntegrationTests;
 
 public class ManagementIntegrationTests : BaseIntegrationTest
 {
+    public ManagementIntegrationTests(ITestOutputHelper output) : base(output)
+    {
+    }
+    
     #region Firewall Tests
 
     [Fact(DisplayName = "TC01: Firewall Enroll No Bindings")]
@@ -550,7 +555,57 @@ public class ManagementIntegrationTests : BaseIntegrationTest
         {
             StorePath =
                 "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificatesTemplate']/config/shared",
-            DeviceGroup = "Group1;Group1", // This will be treated as separate device groups in the app code.
+            DeviceGroup = "Group1;Group1;Group1", // This will be treated as separate device groups in the app code.
+            Alias = alias,
+            Overwrite = false,
+
+            CertificateContents = certificateContent,
+            CertificatePassword = MockCertificatePassword,
+            TemplateStack = ""
+        };
+        props.AddPanoramaCredentials();
+
+        var result = ProcessManagementAddJob(props);
+
+        AssertJobSuccess(result, "Add");
+    }
+    
+    [Fact(DisplayName = "TC16d: Panorama No Overwrite with No Device Group But TemplateStack Defined Adds to Panorama and Firewalls")]
+    public void TestCase16d_PanoramaEnroll_NoOverwrite_NoDeviceGroups_WithTemplateStack_AddsToPanoramaAndFirewalls()
+    {
+        var alias = AliasGenerator.Generate();
+        var certificateContent = PfxGenerator.GetBlobWithChain(alias, MockCertificatePassword);
+
+        var props = new TestManagementJobConfigurationProperties()
+        {
+            StorePath =
+                "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificatesTemplate']/config/shared",
+            DeviceGroup = "",
+            Alias = alias,
+            Overwrite = false,
+
+            CertificateContents = certificateContent,
+            CertificatePassword = MockCertificatePassword,
+            TemplateStack = "CertificatesStack"
+        };
+        props.AddPanoramaCredentials();
+
+        var result = ProcessManagementAddJob(props);
+
+        AssertJobSuccess(result, "Add");
+    }
+    
+    [Fact(DisplayName = "TC16e: Panorama No Overwrite with No Device Group And No TemplateStack Defined Adds to Panorama and Firewalls")]
+    public void TestCase16e_PanoramaEnroll_NoOverwrite_NoDeviceGroups_NoTemplateStack_AddsToPanoramaAndFirewalls()
+    {
+        var alias = AliasGenerator.Generate();
+        var certificateContent = PfxGenerator.GetBlobWithChain(alias, MockCertificatePassword);
+
+        var props = new TestManagementJobConfigurationProperties()
+        {
+            StorePath =
+                "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificatesTemplate']/config/shared",
+            DeviceGroup = "",
             Alias = alias,
             Overwrite = false,
 

--- a/PaloAlto.IntegrationTests/PaloAlto.IntegrationTests.csproj
+++ b/PaloAlto.IntegrationTests/PaloAlto.IntegrationTests.csproj
@@ -23,6 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\PaloAlto.Tests.Common\PaloAlto.Tests.Common.csproj" />
       <ProjectReference Include="..\PaloAlto\PaloAlto.csproj" />
     </ItemGroup>
 
@@ -30,6 +31,10 @@
       <None Update=".env.test">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="TestUtilities\" />
     </ItemGroup>
 
 </Project>

--- a/PaloAlto.Tests.Common/PaloAlto.Tests.Common.csproj
+++ b/PaloAlto.Tests.Common/PaloAlto.Tests.Common.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+      <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    </ItemGroup>
+
+</Project>

--- a/PaloAlto.Tests.Common/TestUtilities/XunitLogger.cs
+++ b/PaloAlto.Tests.Common/TestUtilities/XunitLogger.cs
@@ -1,0 +1,46 @@
+// Copyright 2025 Keyfactor
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace PaloAlto.Tests.Common.TestUtilities;
+
+public class XunitLogger : ILogger
+{
+    private readonly ITestOutputHelper _output;
+
+    public XunitLogger(string _, ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => null!;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel, 
+        EventId eventId, 
+        TState state, 
+        Exception? exception, 
+        Func<TState, Exception?, string> formatter)
+    {
+        _output.WriteLine($"[{logLevel}] {formatter(state, exception)}");
+
+        if (exception != null)
+        {
+            _output.WriteLine(exception.ToString());
+        }
+    }
+}

--- a/PaloAlto.Tests.Common/TestUtilities/XunitLoggerProvider.cs
+++ b/PaloAlto.Tests.Common/TestUtilities/XunitLoggerProvider.cs
@@ -1,0 +1,35 @@
+// Copyright 2025 Keyfactor
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace PaloAlto.Tests.Common.TestUtilities;
+
+public class XunitLoggerProvider : ILoggerProvider
+{
+    private readonly ITestOutputHelper _output;
+
+    public XunitLoggerProvider(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new XunitLogger(categoryName, _output);
+    }
+
+    public void Dispose() { }
+}

--- a/PaloAlto.UnitTests/BaseUnitTest.cs
+++ b/PaloAlto.UnitTests/BaseUnitTest.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+using PaloAlto.Tests.Common.TestUtilities;
+using Xunit.Abstractions;
+
+namespace PaloAlto.UnitTests;
+
+public abstract class BaseUnitTest
+{
+    protected readonly ILogger Logger;
+    
+    public BaseUnitTest(ITestOutputHelper output)
+    {
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .SetMinimumLevel(LogLevel.Trace)
+                .AddProvider(new XunitLoggerProvider(output));
+        });
+        
+        Logger = loggerFactory.CreateLogger<BaseUnitTest>();
+    }
+}

--- a/PaloAlto.UnitTests/Helpers/PanoramaTemplateStackFinderTests.cs
+++ b/PaloAlto.UnitTests/Helpers/PanoramaTemplateStackFinderTests.cs
@@ -1,0 +1,325 @@
+using Keyfactor.Extensions.Orchestrator.PaloAlto.Client;
+using Keyfactor.Extensions.Orchestrator.PaloAlto.Helpers;
+using Keyfactor.Extensions.Orchestrator.PaloAlto.Models.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+using PaloAlto.Tests.Common.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PaloAlto.UnitTests.Helpers
+{
+    public class PanoramaTemplateStackFinderTests : BaseUnitTest
+    {
+        private readonly Mock<IPaloAltoClient> _paloAltoClient;
+        private readonly PanoramaTemplateStackFinder _sut;
+
+        public PanoramaTemplateStackFinderTests(ITestOutputHelper output) : base(output)
+        {
+            _paloAltoClient = new Mock<IPaloAltoClient>();
+            _sut = new PanoramaTemplateStackFinder(_paloAltoClient.Object, Logger);
+        }
+
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupsEmpty_WhenTemplateStackEmpty_ReturnsEmptyList()
+        {
+            var deviceGroups = new List<string>();
+            var template = "template-1";
+            var templateStack = "";
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupsEmpty_WhenTemplateStackNull_ReturnsEmptyList()
+        {
+            var deviceGroups = new List<string>();
+            var template = "template-1";
+            string? templateStack = null;
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupsEmpty_WhenTemplateStackProvided_ReturnsTemplateStack()
+        {
+            var deviceGroups = new List<string>();
+            var template = "template-1";
+            string templateStack = "test-stack";
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Single(result);
+
+            Assert.Equal("test-stack", result.First());
+        }
+
+        [Fact]
+        public async Task
+            GetTemplateStacks_WhenDeviceGroupsNotEmpty_WhenTemplateStackEmpty_ReturnsTemplateStackAssociatedWithDeviceGroups()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "";
+
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+                new()
+                {
+                    Name = "dg-1",
+                    ReferenceTemplates = new List<string>() { "template-1" }
+                },
+                new()
+                {
+                    Name = "dg-2",
+                    ReferenceTemplates = new List<string>() { "template-2" }
+                },
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+                new()
+                {
+                    Name = "template-stack-1",
+                    Templates = new List<string>() { "template-1", "template-2" }
+                },
+                new()
+                {
+                    Name = "template-stack-2",
+                    Templates = new List<string>() { "template-1", "template-3" }
+                },
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("template-stack-1", result[0]);
+            Assert.Equal("template-stack-2", result[1]);
+        }
+
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupsNotEmpty_WhenTemplateStackNotEmpty_ReturnsUniqueSet()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "template-stack-1";
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+                new()
+                {
+                    Name = "dg-1",
+                    ReferenceTemplates = new List<string>() { "template-1" }
+                },
+                new()
+                {
+                    Name = "dg-2",
+                    ReferenceTemplates = new List<string>() { "template-2" }
+                },
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+                new()
+                {
+                    Name = "template-stack-1",
+                    Templates = new List<string>() { "template-1", "template-2" }
+                },
+                new()
+                {
+                    Name = "template-stack-2",
+                    Templates = new List<string>() { "template-1", "template-3" }
+                },
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("template-stack-1", result[0]);
+            Assert.Equal("template-stack-2", result[1]);
+        }
+        
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupsContainMultipleReferenceTemplates_ReturnsUniqueSet()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "";
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+                new()
+                {
+                    Name = "dg-1",
+                    ReferenceTemplates = new List<string>() { "template-1", "template-2", "template-3"  }
+                },
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+                new()
+                {
+                    Name = "template-stack-1",
+                    Templates = new List<string>() { "template-1"}
+                },
+                new()
+                {
+                    Name = "template-stack-2",
+                    Templates = new List<string>() { "template-1" }
+                },
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("template-stack-1", result[0]);
+            Assert.Equal("template-stack-2", result[1]);
+        }
+        
+        [Fact]
+        public async Task GetTemplateStacks_WhenDeviceGroupNotFoundInRemoteSystem_DoesNotReturnTemplateStacks()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "";
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+                new()
+                {
+                    Name = "template-stack-1",
+                    Templates = new List<string>() { "template-1" }
+                }
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+        
+        [Fact]
+        public async Task GetTemplateStacks_WhenTemplateStackNotFoundInRemoteSystem_DoesNotReturnTemplateStacks()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "";
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+                new()
+                {
+                    Name = "dg-1",
+                    ReferenceTemplates = new List<string>() { "template-1", "template-2", "template-3"  }
+                },
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+        
+        [Fact]
+        public async Task GetTemplateStacks_WhenTemplateNameDoesNotMatchDeviceGroup_DoesNotReturnTemplateStack()
+        {
+            var deviceGroups = new List<string> { "dg-1" };
+            var template = "template-1";
+            string templateStack = "";
+
+            var remoteDeviceGroups = new List<DeviceGroup>
+            {
+                new()
+                {
+                    Name = "dg-1",
+                    ReferenceTemplates = new List<string>() { "template-2" }
+                },
+            };
+
+            var remoteTemplateStacks = new List<TemplateStack>
+            {
+                new()
+                {
+                    Name = "template-stack-1",
+                    Templates = new List<string>() { "template-1", "template-2" }
+                },
+                new()
+                {
+                    Name = "template-stack-2",
+                    Templates = new List<string>() { "template-1", "template-3" }
+                },
+            };
+
+            SetupDeviceGroupResponse(remoteDeviceGroups);
+            SetupTemplateStackResponse(remoteTemplateStacks);
+            
+            var result = await _sut.GetTemplateStacks(deviceGroups, template, templateStack);
+            
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        private void SetupDeviceGroupResponse(List<DeviceGroup> deviceGroups)
+        {
+            _paloAltoClient
+                .Setup(p => p.GetDeviceGroups())
+                .ReturnsAsync(new DeviceGroupsResponse
+                {
+                    Result = new DeviceGroupsResult
+                    {
+                        DeviceGroups = deviceGroups,
+                    }
+                });
+        }
+
+        private void SetupTemplateStackResponse(List<TemplateStack> templateStacks)
+        {
+            _paloAltoClient
+                .Setup(p => p.GetTemplateStacks())
+                .ReturnsAsync(new TemplateStacksResponse
+                {
+                    Result = new TemplateStackResult
+                    {
+                        TemplateStacks = templateStacks,
+                    }
+                });
+        }
+    }
+}

--- a/PaloAlto.UnitTests/PaloAlto.UnitTests.csproj
+++ b/PaloAlto.UnitTests/PaloAlto.UnitTests.csproj
@@ -23,6 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\PaloAlto.Tests.Common\PaloAlto.Tests.Common.csproj" />
       <ProjectReference Include="..\PaloAlto\PaloAlto.csproj" />
     </ItemGroup>
 

--- a/PaloAlto.UnitTests/ValidatorsTests.cs
+++ b/PaloAlto.UnitTests/ValidatorsTests.cs
@@ -19,23 +19,24 @@ using Keyfactor.Extensions.Orchestrator.PaloAlto.Models.SupportingObjects;
 using Keyfactor.Orchestrators.Common.Enums;
 using Moq;
 using Xunit;
+
 namespace PaloAlto.UnitTests;
 
 public class ValidatorsTests
 {
     private readonly Mock<IPaloAltoClient> _paloAltoClientMock;
     private readonly IPaloAltoClient _paloAltoClient;
-    
+
     public ValidatorsTests()
     {
         _paloAltoClientMock = new Mock<IPaloAltoClient>();
         _paloAltoClient = _paloAltoClientMock.Object;
     }
-    
+
     #region BuildPaloError
-    
+
     [Fact]
-    public async Task BuildPaloError_WithNoLineMsg_ReturnsEmptyString()
+    public void BuildPaloError_WithNoLineMsg_ReturnsEmptyString()
     {
         var errorResponse = new ErrorSuccessResponse()
         {
@@ -44,13 +45,13 @@ public class ValidatorsTests
                 Line = new List<string>()
             }
         };
-        
+
         var result = Validators.BuildPaloError(errorResponse);
         Assert.Equal("", result);
     }
-    
+
     [Fact]
-    public async Task BuildPaloError_WithSingleLineMsg_ReturnsMessageString()
+    public void BuildPaloError_WithSingleLineMsg_ReturnsMessageString()
     {
         var errorResponse = new ErrorSuccessResponse()
         {
@@ -62,13 +63,13 @@ public class ValidatorsTests
                 }
             }
         };
-        
+
         var result = Validators.BuildPaloError(errorResponse);
         Assert.Equal("Hello World!", result);
     }
-    
+
     [Fact]
-    public async Task BuildPaloError_WithMultipleLineMsg_ReturnsConcatenatedString()
+    public void BuildPaloError_WithMultipleLineMsg_ReturnsConcatenatedString()
     {
         var errorResponse = new ErrorSuccessResponse()
         {
@@ -81,155 +82,159 @@ public class ValidatorsTests
                 }
             }
         };
-        
+
         var result = Validators.BuildPaloError(errorResponse);
         Assert.Equal("Hello World!, Fizz Buzz!", result);
     }
-    
+
     #endregion
 
     #region IsValidPanoramaFormat
 
     [Fact]
-    public async Task IsValidPanoramaFormat_WithNoMatch_ReturnsFalse()
+    public void IsValidPanoramaFormat_WithNoMatch_ReturnsFalse()
     {
         var input = "/home/etc";
 
         var result = Validators.IsValidPanoramaFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaFormat_WithDeviceEntryAndNoCertificateTemplate_ReturnsFalse()
+    public void IsValidPanoramaFormat_WithDeviceEntryAndNoCertificateTemplate_ReturnsFalse()
     {
         var input = "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='']/config/shared";
 
         var result = Validators.IsValidPanoramaFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaFormat_WithNoDeviceEntryAndCertificateTemplate_ReturnsFalse()
+    public void IsValidPanoramaFormat_WithNoDeviceEntryAndCertificateTemplate_ReturnsFalse()
     {
         var input = "/config/devices/entry[@name='']/template/entry[@name='CertificatesTemplate']/config/shared";
 
         var result = Validators.IsValidPanoramaFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaFormat_WithNonLocalhostDeviceEntryAndCertificateTemplate_ReturnsTrue()
+    public void IsValidPanoramaFormat_WithNonLocalhostDeviceEntryAndCertificateTemplate_ReturnsTrue()
     {
-        var input = "/config/devices/entry[@name='somethingrandom']/template/entry[@name='CertificatesTemplate']/config/shared";
+        var input =
+            "/config/devices/entry[@name='somethingrandom']/template/entry[@name='CertificatesTemplate']/config/shared";
 
         var result = Validators.IsValidPanoramaFormat(input);
         Assert.True(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaFormat_WithDeviceEntryAndCertificateTemplate_ReturnsTrue()
+    public void IsValidPanoramaFormat_WithDeviceEntryAndCertificateTemplate_ReturnsTrue()
     {
-        var input = "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificatesTemplate']/config/shared";
+        var input =
+            "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificatesTemplate']/config/shared";
 
         var result = Validators.IsValidPanoramaFormat(input);
         Assert.True(result);
     }
-    
+
     #endregion
-    
+
     #region IsValidFirewallVsysFormat
 
     [Fact]
-    public async Task IsValidFirewallVsysFormat_WithNoMatch_ReturnsFalse()
+    public void IsValidFirewallVsysFormat_WithNoMatch_ReturnsFalse()
     {
         var input = "/home/etc";
 
         var result = Validators.IsValidFirewallVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidFirewallVsysFormat_WithDeviceEntryAndNoVsys_ReturnsFalse()
+    public void IsValidFirewallVsysFormat_WithDeviceEntryAndNoVsys_ReturnsFalse()
     {
         var input = "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='']";
 
         var result = Validators.IsValidFirewallVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidFirewallVsysFormat_WithNoDeviceEntryAndVsys_ReturnsFalse()
+    public void IsValidFirewallVsysFormat_WithNoDeviceEntryAndVsys_ReturnsFalse()
     {
         var input = "/config/devices/entry[@name='']/vsys/entry[@name='System']";
 
         var result = Validators.IsValidFirewallVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidFirewallVsysFormat_WithNonLocalhostDeviceEntryAndCertificateTemplate_ReturnsFalse()
+    public void IsValidFirewallVsysFormat_WithNonLocalhostDeviceEntryAndCertificateTemplate_ReturnsFalse()
     {
         var input = "/config/devices/entry[@name='somethingrandom']/vsys/entry[@name='System']";
 
         var result = Validators.IsValidFirewallVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidFirewallVsysFormat_WithDeviceEntryAndCertificateTemplate_ReturnsTrue()
+    public void IsValidFirewallVsysFormat_WithDeviceEntryAndCertificateTemplate_ReturnsTrue()
     {
         var input = "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='System']";
 
         var result = Validators.IsValidFirewallVsysFormat(input);
         Assert.True(result);
     }
-    
+
     #endregion
-    
+
     #region IsValidPanoramaVsysFormat
 
     [Fact]
-    public async Task IsValidPanoramaVsysFormat_WithNoMatch_ReturnsFalse()
+    public void IsValidPanoramaVsysFormat_WithNoMatch_ReturnsFalse()
     {
         var input = "/home/etc";
 
         var result = Validators.IsValidPanoramaVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaVsysFormat_WithTemplateEntryAndNoVsysEntry_ReturnsFalse()
+    public void IsValidPanoramaVsysFormat_WithTemplateEntryAndNoVsysEntry_ReturnsFalse()
     {
-        var input = "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='']";
+        var input =
+            "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='']";
 
         var result = Validators.IsValidPanoramaVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaVsysFormat_WithNoTemplateEntryAndVsysEntry_ReturnsFalse()
+    public void IsValidPanoramaVsysFormat_WithNoTemplateEntryAndVsysEntry_ReturnsFalse()
     {
         var input = "/config/devices/entry/template/entry[@name='']/config/devices/entry/vsys/entry[@name='System']";
 
         var result = Validators.IsValidPanoramaVsysFormat(input);
         Assert.False(result);
     }
-    
+
     [Fact]
-    public async Task IsValidPanoramaVsysFormat_WithTemplateEntryAndVsysEntry_ReturnsTrue()
+    public void IsValidPanoramaVsysFormat_WithTemplateEntryAndVsysEntry_ReturnsTrue()
     {
-        var input = "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']";
+        var input =
+            "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']";
 
         var result = Validators.IsValidPanoramaVsysFormat(input);
         Assert.True(result);
     }
-    
+
     #endregion
 
     #region ValidateStoreProperties
 
     [Fact]
-    public async Task
+    public void
         ValidateStoreProperties_WhenStorePathIsNotConfigPanoramaOrConfigShared_StorePathIsNotValidFormat_ReturnsError()
     {
         var properties = new JobProperties();
@@ -237,21 +242,23 @@ public class ValidatorsTests
         var jobHistoryId = (long)1234;
 
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
-        
+
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
         Assert.Equal(1234, result.JobHistoryId);
         Assert.Equal("The store setup is not valid. Path is invalid " +
                      "needs to be /config/panorama, /config/shared or in format of " +
                      "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='TemplateName']/config/shared " +
-                     "or /config/devices/entry/template/entry[@name='TemplateName']/config/devices/entry/vsys/entry[@name='VsysName']", result.FailureMessage);
+                     "or /config/devices/entry/template/entry[@name='TemplateName']/config/devices/entry/vsys/entry[@name='VsysName']",
+            result.FailureMessage);
     }
-    
+
     [Theory]
     [InlineData("/config/panorama")]
     [InlineData("/config/shared")]
-    public async Task
-        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesContainsDeviceGroup_ReturnsError(string storePath)
+    public void
+        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesContainsDeviceGroup_ReturnsError(
+            string storePath)
     {
         var properties = new JobProperties()
         {
@@ -260,19 +267,22 @@ public class ValidatorsTests
         var jobHistoryId = (long)1234;
 
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
-        
+
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
         Assert.Equal(1234, result.JobHistoryId);
-        Assert.Equal("The store setup is not valid. You do not need a device group with a Palo Alto Firewall.  It is only required for Panorama.", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. You do not need a device group with a Palo Alto Firewall.  It is only required for Panorama.",
+            result.FailureMessage);
     }
-    
+
     [Theory]
     [InlineData("/config/panorama")]
     [InlineData("/config/shared")]
     [InlineData("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='System']")]
-    public async Task
-        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesContainsTemplateStack_ReturnsError(string storePath)
+    public void
+        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesContainsTemplateStack_ReturnsError(
+            string storePath)
     {
         var properties = new JobProperties()
         {
@@ -281,19 +291,22 @@ public class ValidatorsTests
         var jobHistoryId = (long)1234;
 
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
-        
+
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
         Assert.Equal(1234, result.JobHistoryId);
-        Assert.Equal("The store setup is not valid. You do not need a Template Stack with a Palo Alto Firewall.  It is only required for Panorama.", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. You do not need a Template Stack with a Palo Alto Firewall.  It is only required for Panorama.",
+            result.FailureMessage);
     }
-    
+
     [Theory]
     [InlineData("/config/panorama")]
     [InlineData("/config/shared")]
     [InlineData("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='System']")]
-    public async Task
-        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesAreValid_ReturnsTrue(string storePath)
+    public void
+        ValidateStoreProperties_WhenStorePathDoesNotContainTemplate_StorePropertiesAreValid_ReturnsTrue(
+            string storePath)
     {
         var properties = new JobProperties();
         var jobHistoryId = (long)1234;
@@ -302,13 +315,15 @@ public class ValidatorsTests
         Assert.True(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Unknown, result.Result); // a new JobResult object is instantiated.
     }
-    
+
     #region DeviceGroup Check
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_DeviceGroupIsNotFound_ReturnsError(string storePath)
     {
         var properties = new JobProperties()
@@ -316,7 +331,7 @@ public class ValidatorsTests
             DeviceGroup = "Group1"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetDeviceGroupList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -347,13 +362,17 @@ public class ValidatorsTests
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
-        Assert.Equal("The store setup is not valid. Could not find Device Group(s) Group1 In Panorama.  Valid Device Groups are: Group2", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. Could not find Device Group(s) Group1 In Panorama.  Valid Device Groups are: Group2",
+            result.FailureMessage);
     }
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_DeviceGroupIsFound_ReturnsTrue(string storePath)
     {
         var properties = new JobProperties()
@@ -361,7 +380,7 @@ public class ValidatorsTests
             DeviceGroup = "Group1"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetDeviceGroupList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -397,17 +416,20 @@ public class ValidatorsTests
     #region Multiple Device Groups
 
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
-        ValidateStoreProperties_WhenStorePathContainsTemplate_MultipleDeviceGroups_OneDeviceGroupNotFound_ReturnsError(string storePath)
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
+        ValidateStoreProperties_WhenStorePathContainsTemplate_MultipleDeviceGroups_OneDeviceGroupNotFound_ReturnsError(
+            string storePath)
     {
         var properties = new JobProperties()
         {
             DeviceGroup = "Group1;Group2;Group3;Group4"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetDeviceGroupList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -442,21 +464,26 @@ public class ValidatorsTests
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
-        Assert.Equal("The store setup is not valid. Could not find Device Group(s) Group3, Group4 In Panorama.  Valid Device Groups are: Group1, Group2", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. Could not find Device Group(s) Group3, Group4 In Panorama.  Valid Device Groups are: Group1, Group2",
+            result.FailureMessage);
     }
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
-        ValidateStoreProperties_WhenStorePathContainsTemplate_MultipleDeviceGroups_AllDeviceGroupFound_ReturnsTrue(string storePath)
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
+        ValidateStoreProperties_WhenStorePathContainsTemplate_MultipleDeviceGroups_AllDeviceGroupFound_ReturnsTrue(
+            string storePath)
     {
         var properties = new JobProperties()
         {
             DeviceGroup = "Group1;Group2;Group3"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetDeviceGroupList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -502,15 +529,17 @@ public class ValidatorsTests
     }
 
     #endregion
-    
+
     #endregion
-    
+
     #region TemplateStack Check
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_TemplateStackIsNotFound_ReturnsError(string storePath)
     {
         var properties = new JobProperties()
@@ -518,7 +547,7 @@ public class ValidatorsTests
             TemplateStack = "Stack1"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetTemplateStackList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -549,13 +578,17 @@ public class ValidatorsTests
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
-        Assert.Equal("The store setup is not valid. Could not find your Template Stacks In Panorama.  Valid Template Stacks are Stack2", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. Could not find your Template Stacks In Panorama.  Valid Template Stacks are Stack2",
+            result.FailureMessage);
     }
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_TemplateStackIsFound_ReturnsValid(string storePath)
     {
         var properties = new JobProperties()
@@ -563,7 +596,7 @@ public class ValidatorsTests
             TemplateStack = "Stack1"
         };
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetTemplateStackList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -595,20 +628,22 @@ public class ValidatorsTests
         Assert.True(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Unknown, result.Result); // Instantiates new JobResult object
     }
-    
+
     #endregion
-    
+
     #region TemplateList Check
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_TemplateListIsNotFound_ReturnsError(string storePath)
     {
         var properties = new JobProperties();
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetTemplateStackList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -632,18 +667,22 @@ public class ValidatorsTests
         var (valid, result) = Validators.ValidateStoreProperties(properties, storePath, _paloAltoClient, jobHistoryId);
         Assert.False(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Failure, result.Result);
-        Assert.Equal("The store setup is not valid. Could not find your Template In Panorama.  Valid Templates are SomethingRandom", result.FailureMessage);
+        Assert.Equal(
+            "The store setup is not valid. Could not find your Template In Panorama.  Valid Templates are SomethingRandom",
+            result.FailureMessage);
     }
-    
+
     [Theory]
-    [InlineData("/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
-    [InlineData("/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
-    public async Task
+    [InlineData(
+        "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='CertificateStack']/config/shared")]
+    [InlineData(
+        "/config/devices/entry/template/entry[@name='CertificateStack']/config/devices/entry/vsys/entry[@name='System']")]
+    public void
         ValidateStoreProperties_WhenStorePathContainsTemplate_TemplateListIsFound_ReturnsValid(string storePath)
     {
         var properties = new JobProperties();
         var jobHistoryId = (long)1234;
-        
+
         _paloAltoClientMock.Setup(p => p.GetTemplateStackList()).ReturnsAsync(new NamedListResponse()
         {
             Result = new NamedListResult()
@@ -668,35 +707,35 @@ public class ValidatorsTests
         Assert.True(valid);
         Assert.Equal(OrchestratorJobStatusJobResult.Unknown, result.Result); // Instantiates new JobResult object
     }
-    
+
     #endregion
-    
+
     #endregion
 
     #region GetDeviceGroups
-    
+
     [Fact]
-    public async Task GetDeviceGroups_WhenDeviceGroupsInputIsNull_ReturnsEmptyList()
+    public void GetDeviceGroups_WhenDeviceGroupsInputIsNull_ReturnsEmptyList()
     {
-        string deviceGroupsProperty = null;
+        string? deviceGroupsProperty = null;
 
         var result = Validators.GetDeviceGroups(deviceGroupsProperty);
-        
+
         Assert.Empty(result);
     }
 
     [Fact]
-    public async Task GetDeviceGroups_WhenDeviceGroupsInputIsEmpty_ReturnsEmptyList()
+    public void GetDeviceGroups_WhenDeviceGroupsInputIsEmpty_ReturnsEmptyList()
     {
         string deviceGroupsProperty = "";
 
         var result = Validators.GetDeviceGroups(deviceGroupsProperty);
-        
+
         Assert.Empty(result);
     }
-    
+
     [Fact]
-    public async Task GetDeviceGroups_WhenDeviceGroupsInputHasSingleEntry_ReturnsListWithEntry()
+    public void GetDeviceGroups_WhenDeviceGroupsInputHasSingleEntry_ReturnsListWithEntry()
     {
         string deviceGroupsProperty = "Group 1";
 
@@ -705,9 +744,9 @@ public class ValidatorsTests
         Assert.Equal(1, result.Count);
         Assert.Equal("Group 1", result.First());
     }
-    
+
     [Fact]
-    public async Task GetDeviceGroups_WhenDeviceGroupsInputHasMultipleSemicolonDelimitedEntries_ReturnsListWithEntries()
+    public void GetDeviceGroups_WhenDeviceGroupsInputHasMultipleSemicolonDelimitedEntries_ReturnsListWithEntries()
     {
         string deviceGroupsProperty = "Group 1;Group 2;Group3;Random_Group-123.456";
 
@@ -719,12 +758,13 @@ public class ValidatorsTests
         Assert.Equal("Group3", result.ElementAt(2));
         Assert.Equal("Random_Group-123.456", result.ElementAt(3));
     }
-    
+
     [Fact]
-    public async Task GetDeviceGroups_WhenDeviceGroupsInputHasMultipleSemicolonDelimitedEntries_WithSpaces_ReturnsListWithEntries()
+    public void
+        GetDeviceGroups_WhenDeviceGroupsInputHasMultipleSemicolonDelimitedEntries_WithSpaces_ReturnsListWithEntries()
     {
         string deviceGroupsProperty = "Group 1    ;Group 2;     Group 3";
-        
+
         var result = Validators.GetDeviceGroups(deviceGroupsProperty);
 
         Assert.Equal(3, result.Count);

--- a/PaloAlto.sln
+++ b/PaloAlto.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaloAlto.IntegrationTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaloAlto.UnitTests", "PaloAlto.UnitTests\PaloAlto.UnitTests.csproj", "{30B1C65A-AFBF-42AC-BB6B-4C755D0B08F3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaloAlto.Tests.Common", "PaloAlto.Tests.Common\PaloAlto.Tests.Common.csproj", "{86AA8249-1299-415D-BC42-A829EE4B8E4F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{30B1C65A-AFBF-42AC-BB6B-4C755D0B08F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30B1C65A-AFBF-42AC-BB6B-4C755D0B08F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30B1C65A-AFBF-42AC-BB6B-4C755D0B08F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86AA8249-1299-415D-BC42-A829EE4B8E4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86AA8249-1299-415D-BC42-A829EE4B8E4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86AA8249-1299-415D-BC42-A829EE4B8E4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86AA8249-1299-415D-BC42-A829EE4B8E4F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,6 +60,7 @@ Global
 		{6302034E-DF8C-4B65-AC36-CED24C068999} = {1A6C93E7-24FD-47FD-883D-EDABF5CEE4C6}
 		{94D8FD54-A92A-4453-991F-3EFFF1493E07} = {F618499B-AFF5-489D-AE01-6B7AA75CDBCD}
 		{30B1C65A-AFBF-42AC-BB6B-4C755D0B08F3} = {F618499B-AFF5-489D-AE01-6B7AA75CDBCD}
+		{86AA8249-1299-415D-BC42-A829EE4B8E4F} = {F618499B-AFF5-489D-AE01-6B7AA75CDBCD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E0FA12DA-6B82-4E64-928A-BB9965E636C1}

--- a/PaloAlto/Client/IPaloAltoClient.cs
+++ b/PaloAlto/Client/IPaloAltoClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Keyfactor.Extensions.Orchestrator.PaloAlto.Models.Responses;
 
@@ -24,7 +25,7 @@ public interface IPaloAltoClient
     Task<NamedListResponse> GetDeviceGroupList();
     Task<NamedListResponse> GetTemplateStackList();
     Task<CommitResponse> GetCommitResponse();
-    Task<CommitResponse> GetCommitAllResponse(string deviceGroup,string storePath,string templateStack);
+    Task<CommitResponse> GetCommitAllResponse(IReadOnlyCollection<string> deviceGroups,string storePath,string templateStack);
     Task<TrustedRootListResponse> GetTrustedRootList();
     Task<string> GetCertificateByName(string name);
     Task<ErrorSuccessResponse> SubmitDeleteCertificate(string name, string storePath);
@@ -32,6 +33,8 @@ public interface IPaloAltoClient
     Task<ErrorSuccessResponse> SubmitSetTrustedRoot(string name, string storePath);
     Task<ErrorSuccessResponse> SetPanoramaTarget(string storePath);
     Task<JobStatusResponse> GetJobStatus(string jobId);
+    Task<DeviceGroupsResponse> GetDeviceGroups();
+    Task<TemplateStacksResponse> GetTemplateStacks();
 
     Task<ErrorSuccessResponse> ImportCertificate(string name, string passPhrase, byte[] bytes,
         string includeKey, string category, string storePath);

--- a/PaloAlto/Client/PaloAltoClient.cs
+++ b/PaloAlto/Client/PaloAltoClient.cs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
@@ -128,7 +129,6 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
             {
                 var uri =
                     $"/api/?&type=commit&action=partial&cmd=<commit><partial><admin><member>{ServerUserName}</member></admin></partial></commit>&key={ApiKey}";
-
                 var response = await GetXmlResponseAsync<CommitResponse>(await HttpClient.GetAsync(uri));
                 return response;
             }
@@ -139,7 +139,7 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
             }
         }
 
-        public async Task<CommitResponse> GetCommitAllResponse(string deviceGroup,string storePath,string templateStack)
+        public async Task<CommitResponse> GetCommitAllResponse(IReadOnlyCollection<string> deviceGroups, string storePath,string templateStack)
         {
             try
             {
@@ -147,21 +147,18 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
                 //var uri = $"/api/?&type=commit&action=all&cmd=<commit-all><shared-policy><admin><member>{ServerUserName}</member></admin><device-group><entry name=\"{deviceGroup}\"/></device-group></shared-policy></commit-all>&key={ApiKey}";
                 var uri = string.Empty;
                 CommitResponse response = new ();
+                
                 var jobPoller = new PanoramaJobPoller(this);
-                if (!string.IsNullOrEmpty(deviceGroup))
-                {
-                    foreach (var group in Validators.GetDeviceGroups(deviceGroup))
-                    {
-                        _logger.LogTrace($"Committing changes to device group {group}");
-                        uri = $"/api/?&type=commit&action=all&cmd=<commit-all><shared-policy><device-group><entry name=\"{group}\"/></device-group></shared-policy></commit-all>&key={ApiKey}";
-                        response = await GetXmlResponseAsync<CommitResponse>(await HttpClient.GetAsync(uri));
+                var templateStackFinder = new PanoramaTemplateStackFinder(this, _logger);
+                
+                var template = GetTemplateName(storePath);
+                
+                // Committing to device groups directly is *very* slow. Instead, we need to find the template stacks associated with the device groups.
+                var templateStacks = await templateStackFinder.GetTemplateStacks(deviceGroups, template, templateStack);
 
-                        await HandleCommitResponse(response, jobPoller);
-                    }
-                }
-                else
+                // If there are no device groups present, we need to commit to the template directly
+                if (!deviceGroups.Any())
                 {
-                    var template = GetTemplateName(storePath);
                     _logger.LogTrace($"Committing changes to template {template}");
                     
                     uri =$"/api/?&type=commit&action=all&cmd=<commit-all><template><name>{template}</name></template></commit-all>&key={ApiKey}";
@@ -170,14 +167,16 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
                     await HandleCommitResponse(response, jobPoller);
                 }
 
-                if (!string.IsNullOrEmpty(templateStack))
+                // Loop through all template stacks (even those associated with device groups) and commit to those stacks
+                foreach (var stack in templateStacks)
                 {
-                    _logger.LogTrace($"Committing changes to template stack {templateStack}");
-                    uri = $"/api/?&type=commit&action=all&cmd=<commit-all><template-stack><name>{templateStack}</name></template-stack></commit-all>&key={ApiKey}";
+                    _logger.LogTrace($"Committing changes to template stack {stack}");
+                    uri = $"/api/?&type=commit&action=all&cmd=<commit-all><template-stack><name>{stack}</name></template-stack></commit-all>&key={ApiKey}";
                     response = await GetXmlResponseAsync<CommitResponse>(await HttpClient.GetAsync(uri));
                     
                     await HandleCommitResponse(response, jobPoller);
                 }
+                
                 return response;
             }
             catch (Exception e)
@@ -185,6 +184,35 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
                 _logger.LogError($"Error Occured in PaloAltoClient.GetCommitAllResponse: {e.Message}");
                 throw;
             }
+        }
+
+        public async Task<DeviceGroupsResponse> GetDeviceGroups()
+        {
+            _logger.MethodEntry();
+            
+            var url =
+                $"/api/?type=config&action=get&xpath=/config/devices/entry[@name='localhost.localdomain']/device-group&key={ApiKey}";
+            var deviceGroups = await GetXmlResponseAsync<DeviceGroupsResponse>(await HttpClient.GetAsync(url));
+
+            if (deviceGroups.Result.Count != deviceGroups.Result.TotalCount)
+            {
+                _logger.LogWarning($"Panorama API returned a different number of device groups than expected total. Retrieved {deviceGroups.Result.Count} but expected {deviceGroups.Result.TotalCount}. Results may be truncated.");
+            }
+
+            _logger.MethodExit();
+            return deviceGroups;
+        }
+
+        public async Task<TemplateStacksResponse> GetTemplateStacks()
+        {
+            _logger.MethodEntry();
+            
+            var url =
+                $"/api/?type=config&action=get&xpath=/config/devices/entry[@name='localhost.localdomain']/template-stack&key={ApiKey}";
+            var stacks = await GetXmlResponseAsync<TemplateStacksResponse>(await HttpClient.GetAsync(url));
+            
+            _logger.MethodExit();
+            return stacks;
         }
 
         private async Task HandleCommitResponse(CommitResponse response, PanoramaJobPoller jobPoller)
@@ -200,7 +228,7 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
             if (response.Result?.HasJobId ?? false)
             {
                 _logger.LogTrace($"Waiting to make sure commit was successful. Job ID: {response.Result?.JobId}...");
-                var result = await jobPoller.WaitForJobCompletion(response.Result.JobId);
+                var result = await jobPoller.WaitForJobCompletion(response.Result!.JobId);
                 if (result.Result == OrchestratorJobStatusJobResult.Failure)
                 {
                     throw new Exception(result.FailureMessage);
@@ -215,7 +243,6 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Client
             var url = $"/api/?type=op&cmd=<show><jobs><id>{jobId}</id></jobs></show>&key={ApiKey}";
             return await GetXmlResponseAsync<JobStatusResponse>(await HttpClient.GetAsync(url));
         }
-
 
         public string GetTemplateName(string storePath)
         {

--- a/PaloAlto/Helpers/PanoramaTemplateStackFinder.cs
+++ b/PaloAlto/Helpers/PanoramaTemplateStackFinder.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Keyfactor.Extensions.Orchestrator.PaloAlto.Client;
+using Keyfactor.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Helpers;
+
+public class PanoramaTemplateStackFinder
+{
+    private readonly IPaloAltoClient _client;
+    private readonly ILogger _logger;
+    
+    public PanoramaTemplateStackFinder(IPaloAltoClient client, ILogger logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns a list of unique template stacks associated with device groups
+    /// and a template, including the provided template stack if specified.
+    /// </summary>
+    /// <param name="deviceGroups">A collection of device groups to push certificates to.</param>
+    /// <param name="template">The template to filter device group associations to.</param>
+    /// <param name="templateStack">A template stack to also push configuration updates to, can be independent of device group match.</param>
+    /// <returns></returns>
+    public async Task<List<string>> GetTemplateStacks(IReadOnlyCollection<string> deviceGroups, string template, string templateStack)
+    {
+        _logger.MethodEntry();
+        _logger.LogDebug($"Finding template stacks for device groups: {string.Join(", ", deviceGroups)} with provided template stack: '{templateStack}'");
+        
+        var result = new List<string>();
+        if (!string.IsNullOrWhiteSpace(templateStack))
+        {
+            _logger.LogDebug($"Adding template stack '{templateStack}' to result as it was provided.");
+            result.Add(templateStack);
+        }
+
+        if (!deviceGroups.Any())
+        {
+            _logger.LogTrace($"No device groups found. Returning template stacks: {string.Join(", ", result)}");
+            _logger.MethodExit();
+            return result;
+        }
+
+        var deviceGroupsList = await _client.GetDeviceGroups();
+        var templates = new List<string>(); // A lookup reference for templates associated with device groups
+
+        foreach (var dg in deviceGroups.Distinct())
+        {
+            var lookup = deviceGroupsList.Result.DeviceGroups.FirstOrDefault(p => p.Name == dg);
+            if (lookup == null)
+            {
+                _logger.LogWarning($"Device group '{dg}' not found in Panorama.");
+                continue;
+            }
+            
+            // Filter referenced templates to only include the specified template
+            // This reduces the chance of adding unrelated template stacks
+            var referencedTemplates = lookup.ReferenceTemplates.Where(p => p == template);
+            
+            templates.AddRange(referencedTemplates);
+        }
+        
+        if (!templates.Any())
+        {
+            _logger.LogTrace($"No templates associated with device groups: {string.Join(", ", deviceGroups)}. Returning template stacks: {string.Join(", ", result)}");
+            _logger.MethodExit();
+            return result;
+        }
+
+        var templatesStackList = await _client.GetTemplateStacks();
+
+        foreach (var stack in templatesStackList.Result.TemplateStacks)
+        {
+            // Add template stacks where the associated templates match the list of templates returned from device group query
+            if (templates.Any(t => stack.Templates.Contains(t)))
+            {
+                _logger.LogDebug($"Adding template stack '{stack.Name}' to result as it contains templates associated with device groups.");
+                result.Add(stack.Name);
+            }
+        }
+        
+        _logger.MethodExit();
+
+        return result.Distinct().ToList();
+    }
+}

--- a/PaloAlto/Jobs/Management.cs
+++ b/PaloAlto/Jobs/Management.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Keyfactor.Extensions.Orchestrator.PaloAlto.Client;
 using Keyfactor.Extensions.Orchestrator.PaloAlto.Helpers;
@@ -47,6 +48,13 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
             _logger = LogHandler.GetClassLogger<Management>();
             _logger.LogTrace("Initialized Management with IPAMSecretResolver.");
         }
+        
+        public Management(IPAMSecretResolver resolver, ILogger logger)
+        {
+            _resolver = resolver;
+            _logger = logger;
+            _logger.LogTrace("Initialized Management with IPAMSecretResolver.");
+        }
 
         private string ServerPassword { get; set; }
 
@@ -60,7 +68,6 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
 
         public JobResult ProcessJob(ManagementJobConfiguration jobConfiguration)
         {
-            _logger = LogHandler.GetClassLogger<Management>();
             _logger.LogTrace($"Processing job with configuration: {JsonConvert.SerializeObject(jobConfiguration)}");
             StoreProperties = JsonConvert.DeserializeObject<JobProperties>(
                 jobConfiguration.CertificateStoreDetails.Properties,
@@ -162,7 +169,9 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
                 $"Alias to Remove From Palo Alto: {config.JobCertificate.Alias}");
                 if (!DeleteCertificate(config, _client, warnings, out var deleteResult)) return deleteResult;
                 _logger.LogTrace("Attempting to Commit Changes for Removal Job...");
-                warnings = CommitChanges(config, _client, warnings);
+                warnings = CommitChanges(config, _client, warnings)
+                    .GetAwaiter()
+                    .GetResult();
                 _logger.LogTrace("Finished Committing Changes.....");
 
                 if (warnings?.Length > 0)
@@ -306,7 +315,9 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
                         if (errorMsg.Length == 0)
                         {
                             _logger.LogTrace("Attempting to Commit Changes, no errors were found");
-                            warnings = CommitChanges(config, client, warnings);
+                            warnings = CommitChanges(config, client, warnings)
+                                .GetAwaiter()
+                                .GetResult();
                         }
 
                         return ReturnJobResult(config, warnings, true, errorMsg);
@@ -482,12 +493,14 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
             return certPem;
         }
 
-        private string CommitChanges(ManagementJobConfiguration config, PaloAltoClient client, string warnings)
+        private async Task<string> CommitChanges(ManagementJobConfiguration config, PaloAltoClient client, string warnings)
         {
             _logger.MethodEntry();
-            var commitResponse = client.GetCommitResponse().Result;
+            
+            var commitResponse = await client.GetCommitResponse();
             _logger.LogTrace("Got client commit response, attempting to log it");
             LogResponse(commitResponse);
+            
             if (commitResponse.Status == "success")
             {
                 _logger.LogTrace("Commit response shows success");
@@ -499,7 +512,7 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
                     // (Panorama has a limit to the number of queued jobs it allows, so we want to make sure this one completes).
                     _logger.LogTrace("Waiting for job to finish");
                     var jobPoller = new PanoramaJobPoller(client);
-                    var completionResult = jobPoller.WaitForJobCompletion(commitResponse.Result.JobId).GetAwaiter().GetResult();
+                    var completionResult = await jobPoller.WaitForJobCompletion(commitResponse.Result.JobId);
 
                     if (completionResult.Result == OrchestratorJobStatusJobResult.Failure)
                     {
@@ -517,7 +530,10 @@ namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Jobs
                 //If there is a template and device group then push to all firewall devices because it is Panorama
                 if (Validators.IsValidPanoramaVsysFormat(config.CertificateStoreDetails.StorePath) || Validators.IsValidPanoramaFormat(config.CertificateStoreDetails.StorePath))
                 {
-                    var commitAllResponse = client.GetCommitAllResponse(deviceGroup, config.CertificateStoreDetails.StorePath, templateStack).Result;
+                    // Split the device groups from the store properties
+                    var deviceGroups = Validators.GetDeviceGroups(deviceGroup);
+                    
+                    var commitAllResponse = await client.GetCommitAllResponse(deviceGroups, config.CertificateStoreDetails.StorePath, templateStack);
                     _logger.LogTrace("Logging commit response from panorama.");
                     LogResponse(commitAllResponse);
                     if (commitAllResponse.Status != "success")

--- a/PaloAlto/Models/Responses/DeviceGroupsResponse.cs
+++ b/PaloAlto/Models/Responses/DeviceGroupsResponse.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Models.Responses
+{
+    [XmlRoot(ElementName = "response")]
+    public class DeviceGroupsResponse
+    {
+        [XmlElement(ElementName = "result")]
+        public DeviceGroupsResult Result { get; set; }
+        
+        [XmlAttribute(AttributeName = "status")]
+        public string Status { get; set; }
+        
+        [XmlAttribute(AttributeName = "code")]
+        public int Code { get; set; }
+    }
+
+    public class DeviceGroupsResult
+    {
+        [XmlArray("device-group")]
+        [XmlArrayItem("entry")]
+        public List<DeviceGroup> DeviceGroups { get; set; }
+        
+        [XmlAttribute(AttributeName = "total-count")]
+        public int TotalCount { get; set; }
+        
+        [XmlAttribute(AttributeName = "count")]
+        public int Count { get; set; }
+    }
+
+    public class DeviceGroup
+    {
+        [XmlAttribute(AttributeName = "name")]
+        public string Name { get; set; }
+
+        [XmlArray("reference-templates")]
+        [XmlArrayItem("member")]
+        public List<string> ReferenceTemplates { get; set; }
+
+        [XmlArray("devices")]
+        [XmlArrayItem("entry")]
+        public List<DeviceEntry> Devices { get; set; }
+    }
+    
+    public class DeviceEntry
+    {
+        [XmlAttribute(AttributeName = "name")]
+        public string Name { get; set; }
+    }
+}
+

--- a/PaloAlto/Models/Responses/TemplateStacksResponse.cs
+++ b/PaloAlto/Models/Responses/TemplateStacksResponse.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Keyfactor.Extensions.Orchestrator.PaloAlto.Models.Responses
+{
+    [XmlRoot(ElementName = "response")]
+    public class TemplateStacksResponse
+    {
+        [XmlElement(ElementName = "result")]
+        public TemplateStackResult Result { get; set; }
+        
+        [XmlAttribute(AttributeName = "status")]
+        public string Status { get; set; }
+        
+        [XmlAttribute(AttributeName = "code")]
+        public int Code { get; set; }
+    }
+
+    public class TemplateStackResult
+    {
+        [XmlArray("template-stack")]
+        [XmlArrayItem("entry")]
+        public List<TemplateStack> TemplateStacks { get; set; }
+    }
+
+    public class TemplateStack
+    {
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+        
+        [XmlArray("templates")]
+        [XmlArrayItem("member")]
+        public List<string> Templates { get; set; }
+    }
+}
+
+

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The Palo Alto Orchestrator Extension is an integration that can replace and inve
 This integration is compatible with Keyfactor Universal Orchestrator version 10.4 and later.
 
 ## Support
-The Palo Alto Universal Orchestrator extension If you have a support issue, please open a support ticket by either contacting your Keyfactor representative or via the Keyfactor Support Portal at https://support.keyfactor.com.
+The Palo Alto Universal Orchestrator extension is supported by Keyfactor. If you require support for any issues or have feature request, please open a support ticket by either contacting your Keyfactor representative or via the Keyfactor Support Portal at https://support.keyfactor.com.
 
-> To report a problem or suggest a new feature, use the **[Issues](../../issues)** tab. If you want to contribute actual bug fixes or proposed enhancements, use the **[Pull requests](../../pulls)** tab.
+> If you want to contribute bug fixes or additional enhancements, use the **[Pull requests](../../pulls)** tab.
 
 ## Requirements & Prerequisites
 


### PR DESCRIPTION
When many device groups are specified, management job performance may be impacted as each device group commit can take a few minutes.

Pushing to device groups does end up pushing certificates to firewalls, but this is mainly done via [template stacks](https://docs.paloaltonetworks.com/panorama/10-2/panorama-admin/panorama-overview/centralized-firewall-configuration-and-update-management/templates-and-template-stacks). Pushing commits to [device groups](https://cordero.me/palo-alto-device-groups-vs-templates/) directly goes through a series of validation and configuration checks, which adds a lot of execution time overhead. Conversely, template stack commits are much quicker.

This feature update changes how commits are pushed to end devices. Using the XML API, the integration will map template stacks from the device group by looking up template associations. 